### PR TITLE
docker build 로직 & kafka 연동

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,36 @@
-# AdoptOpenJDK 17 기반 이미지 사용
-FROM openjdk:17-jdk-slim
+# --- 빌더 스테이지 ---
+# 애플리케이션을 빌드하는 데 사용되는 스테이지
+FROM openjdk:17-jdk-slim AS builder
 
-# 작업 디렉토리 설정
 WORKDIR /app
 
-# Gradle 빌드 결과물(JAR 파일)을 컨테이너 내부로 복사
-# build/libs 디렉토리에 생성되는 JAR 파일 이름을 확인해야 합니다.
-# 예: insurance-project-0.0.1-SNAPSHOT.jar
-COPY build/libs/insurance-project-0.0.1-SNAPSHOT.jar app.jar
+# Gradle 빌드에 필요한 파일들을 먼저 복사하여 캐싱 활용
+COPY gradlew .
+COPY gradle gradle/
+COPY build.gradle .
+COPY settings.gradle .
+COPY src/main src/main
+
+# gradlew 실행 권한 부여
+RUN chmod +x gradlew
+
+# Gradle 빌드 실행
+RUN ./gradlew bootJar --no-daemon -x test
+
+# JAR 파일 생성 확인 (디버깅용)
+RUN ls -l build/libs
+
+# --- 런타임 스테이지 ---
+# 최종 애플리케이션 이미지를 생성하는 스테이지
+FROM eclipse-temurin:17-jre-jammy
+
+WORKDIR /app
+
+# 빌더 스테이지에서 생성된 JAR 파일을 복사
+COPY --from=builder /app/build/libs/insurance-project-0.0.1-SNAPSHOT.jar app.jar
 
 # 애플리케이션이 사용할 포트 노출
 EXPOSE 8080
 
-# 애플리케이션 실행
+# 애플리케이션 실행 명령 정의
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-tomcat'
+	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
   # 2. Spring Boot 애플리케이션
   # 실제 비즈니스 로직이 담긴 핵심 애플리케이션입니다.
   insurance-app:
+    build: .
     image: skyrius6732/insurance-project:latest
     container_name: insurance-project-8081 # 컨테이너 이름을 좀 더 명확하게 변경하는 것을 추천합니다.
     ports:

--- a/src/main/java/com/example/insurance_project/kafka/KafkaConsumerService.java
+++ b/src/main/java/com/example/insurance_project/kafka/KafkaConsumerService.java
@@ -1,0 +1,16 @@
+package com.example.insurance_project.kafka;
+
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class KafkaConsumerService {
+
+    @KafkaListener(topics="test-topic", groupId = "skyrius")
+    public void consume(String message) throws IOException{
+        System.out.println(String.format("Consumed message : %s", message));
+    }
+}

--- a/src/main/java/com/example/insurance_project/kafka/KafkaController.java
+++ b/src/main/java/com/example/insurance_project/kafka/KafkaController.java
@@ -1,0 +1,25 @@
+package com.example.insurance_project.kafka;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kafka")
+public class KafkaController {
+
+    private final KafkaProducerService producerService;
+
+    @Autowired
+    public KafkaController(KafkaProducerService producerService) {
+        this.producerService = producerService;
+    }
+
+    @GetMapping("/{message}")
+    public String sendMessage(@PathVariable("message") String message) {
+        producerService.sendMessage(message);
+        return "Message sent to Kafka topic";
+    }
+}

--- a/src/main/java/com/example/insurance_project/kafka/KafkaProducerService.java
+++ b/src/main/java/com/example/insurance_project/kafka/KafkaProducerService.java
@@ -1,0 +1,18 @@
+package com.example.insurance_project.kafka;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaProducerService {
+    private static final String TOPIC = "test-topic";
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendMessage(String message){
+        System.out.println(String.format("produce message : %s", message));
+        this.kafkaTemplate.send(TOPIC, message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=8080
+spring.kafka.bootstrap-servers=kafka:9092


### PR DESCRIPTION
- docker-compose.yml : spring boot build 추가
- Dockerfile : build 스테이지 추가(docker build시 자체 gradle 빌드 로직 진행)
- application.properties / build.gradle kafka 사용하기 위한 설정 추가
- kafka 예제 소스 추가

Spring Boot 애플리케이션에 Kafka 메시지 발행 및 구독 기능을 추가합니다. Dockerfile을 멀티 스테이지 빌드로 개선하고, Nginx 및 애플리케이션 설정을 조정했습니다.